### PR TITLE
Added int value to the PGConfigKey and file reorganizations

### DIFF
--- a/include/pg_auto_tune.h
+++ b/include/pg_auto_tune.h
@@ -18,6 +18,8 @@
 #ifndef __PG_AUTO_TUNE_H__
 #define __PG_AUTO_TUNE_H__
 
+#include "pg_parse_pgconfig.h"
+
 #define MAX_MESSAGE_LEN 256
 
 typedef enum WORKLOAD_TYPE
@@ -51,13 +53,6 @@ typedef enum HOST_TYPE
     UNKNOWN_HOST
 } HOST_TYPE;
 
-typedef enum PARAM_TYPE
-{
-    CHAR,
-    INT,
-    FLOAT
-} PARAM_TYPE;
-
 typedef struct system_info
 {
     long long total_ram;
@@ -68,23 +63,6 @@ typedef struct system_info
     DISK_TYPE disk_type;
     WORKLOAD_TYPE workload_type;
 } SystemInfo;
-
-typedef struct pg_config_key_value PGConfigKeyVal;
-struct pg_config_key_value
-{
-    char *key;
-    char *value;
-    PGConfigKeyVal *next;
-
-};
-
-typedef struct pg_config
-{
-    int num_params;
-    PGConfigKeyVal *list;
-
-} PGConfig;
-
 
 typedef enum RESOURCES
 {
@@ -140,12 +118,6 @@ typedef struct pg_config_map
     PGConfigMapEntry *list;
 
 } PGConfigMap;
-
-#define MAX_CONFIG_CHAR_VAL 1024
-
-PGConfig *PGConfig_parse(char *path);
-void PGConfig_destroy(PGConfig *config);
-PGConfigKeyVal* get_config_for_param(PGConfig *config, char *param_name);
 
 /* located in pg_config_processor.c */
 void load_pg_config_in_map(PGConfigMap* config_map, PGConfig *pg_config);

--- a/include/pg_config_map.h
+++ b/include/pg_config_map.h
@@ -17,20 +17,20 @@
 #ifndef __PG_CONFIG_MAP_H__
 #define __PG_CONFIG_MAP_H__
 
+#include "pg_parse_pgconfig.h"
 #include "pg_auto_tune.h"
 
-#define MAX_LINE        2048
-#define MAX_TOKEN_LEN   512
+#define MAX_LINE 2048
+#define MAX_TOKEN_LEN 512
 
+// 
 
-
-
-int load_config_map(PGConfigMap* config, char *map_file);
-void free_config_map(PGConfigMap* config);
-char* get_resource_name(RESOURCES res);
-char* get_formula_name(FORMULAS formula);
+int load_config_map(PGConfigMap *config, char *map_file);
+void free_config_map(PGConfigMap *config);
+char *get_resource_name(RESOURCES res);
+char *get_formula_name(FORMULAS formula);
 
 /* DEBUG functions */
-void print_config_map(PGConfigMap* config);
+void print_config_map(PGConfigMap *config);
 void print_config_map_entry(PGConfigMapEntry *entry);
-#endif  // __PG_CONFIG_MAP_H__
+#endif // __PG_CONFIG_MAP_H__

--- a/include/pg_parse_pgconfig.h
+++ b/include/pg_parse_pgconfig.h
@@ -1,0 +1,54 @@
+/*-------------------------------------------------------------------------
+ *
+ * pg_parse_dbconfig.h
+ *		Utility to auto tune PostgreSQL configuration parameters based on system resources.
+ *
+ * Copyright © Percona LLC and/or its affiliates
+ *
+ * Hackathon Team one
+ *  Abdul Sayeed
+ *  Agustin Gallego
+ *  Charly Batista
+ *  Jobin Augustine
+ *  Muhammad Usama
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef __PG_PARSE_PGCONFIG_H__
+#define __PG_PARSE_PGCONFIG_H__
+
+typedef enum PARAM_TYPE
+{
+    CHAR,
+    INT,
+    FLOAT
+} PARAM_TYPE;
+
+typedef struct pg_config_key_value PGConfigKeyVal;
+struct pg_config_key_value
+{
+    char *key;
+    char *value;
+    u_int64_t int_val;
+    PGConfigKeyVal *next;
+
+};
+
+typedef struct pg_config
+{
+    int num_params;
+    PGConfigKeyVal *list;
+
+} PGConfig;
+
+//
+#define MAX_CONFIG_CHAR_VAL 1024
+
+//
+PGConfig *PGConfig_parse(char *path);
+void PGConfig_destroy(PGConfig *config);
+PGConfigKeyVal* PGConfig_get_param_by_name(PGConfig *config, char *param_name);
+
+
+#endif // __PG_PARSE_PGCONFIG_H__

--- a/src/pg_auto_tune.c
+++ b/src/pg_auto_tune.c
@@ -160,7 +160,7 @@ int main(int argc, char **argv)
         case 'D':
             data_dir = strdup(optarg);
             break;
-        
+
         case '?':
         default:
 
@@ -209,7 +209,7 @@ int main(int argc, char **argv)
     pg_config = PGConfig_parse(pgconf_file_path);
 
     /* Load the map file */
-    load_config_map(&config_map, map_file?map_file:map_file_name);
+    load_config_map(&config_map, map_file ? map_file : map_file_name);
     if (verbose_output)
         print_config_map(&config_map);
 
@@ -323,7 +323,7 @@ usage(void)
      */
     fprintf(stderr, "  -h, --host-type=TYPE        TYPE can be \"pod\", \"standard\", or \"cloud\"\n");
     fprintf(stderr, "  -n, --node-type=TYPE        TYPE can be \"primary\", or \"standby\"\n");
-    fprintf(stderr, "  -n, --disk-type=TYPE        TYPE can be \"magnetic\", \"ssd\", or \"network\"\n");
+    fprintf(stderr, "  -d, --disk-type=TYPE        TYPE can be \"magnetic\", \"ssd\", or \"network\"\n");
     fprintf(stderr, "  -n, --worklload-type=TYPE   TYPE can be \"olap\", \"oltp\", or \"mixed\"\n");
 
     fprintf(stderr, "  -m, --file=file-path        path of config map file\n");

--- a/src/pg_auto_tune.c
+++ b/src/pg_auto_tune.c
@@ -324,7 +324,7 @@ usage(void)
     fprintf(stderr, "  -h, --host-type=TYPE        TYPE can be \"pod\", \"standard\", or \"cloud\"\n");
     fprintf(stderr, "  -n, --node-type=TYPE        TYPE can be \"primary\", or \"standby\"\n");
     fprintf(stderr, "  -d, --disk-type=TYPE        TYPE can be \"magnetic\", \"ssd\", or \"network\"\n");
-    fprintf(stderr, "  -n, --worklload-type=TYPE   TYPE can be \"olap\", \"oltp\", or \"mixed\"\n");
+    fprintf(stderr, "  -w, --workload-type=TYPE   TYPE can be \"olap\", \"oltp\", or \"mixed\"\n");
 
     fprintf(stderr, "  -m, --file=file-path        path of config map file\n");
     fprintf(stderr, "  -D, --data-dir=DIR          location of the PostgreSQL data directory\n");

--- a/src/pg_config_processor.c
+++ b/src/pg_config_processor.c
@@ -33,7 +33,7 @@ load_pg_config_in_map(PGConfigMap* config_map, PGConfig *pg_config)
     map_entry = config_map->list;
     while(map_entry)
     {
-        map_entry->conf_ref = get_config_for_param(pg_config,map_entry->param);
+        map_entry->conf_ref = PGConfig_get_param_by_name(pg_config,map_entry->param);
         map_entry = map_entry->next;
     }
 }


### PR DESCRIPTION
Renamed parse_config.c to pg_parse_pgconfig.c
Also renamed the inc file (.h)
Renamed the function get_config_for_param() to PGConfig_get_param_by_name()
Added int value to the key which will be non-zero when it holds an integer. It will take care of the conversion from byte unities (KB, MB, GB, etc). The value will still hold the original string representation
TODO: Still need to work on the float representations because some values like \"seq_page_cost\" are stored as double