### PR TITLE
Fixed error on kB unit

### DIFF
--- a/src/pg_config_map.c
+++ b/src/pg_config_map.c
@@ -378,7 +378,7 @@ create_postgresql_conf(const char *output_file_path,PGConfigMap* config, SystemI
         {
             fprintf(fp, "%s = ", entry->param);
             if (entry->resource == RESOURCE_MEMORY)
-                fprintf(fp, "%lldKB\n",(long long) (entry->optimised_value/1024));
+                fprintf(fp, "%lldkB\n",(long long) (entry->optimised_value/1024));
             else if (entry->resource == RESOURCE_CPU)
                 fprintf(fp, "%lld\n",(long long) entry->optimised_value);
             else


### PR DESCRIPTION
Fixed error on kB unit. Postgres requires the "k" to be lowercase and the "B" uppercase lol